### PR TITLE
Added explicit compose version to docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   app:
     build: .


### PR DESCRIPTION
This makes sure the compose file works for older versions of docker-compose.
[Documentation](https://docs.docker.com/compose/compose-file/compose-versioning/)